### PR TITLE
add medical hud to nanomed vending machines

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -2,6 +2,7 @@
   id: NanoMedPlusInventory
   startingInventory:
     HandheldHealthAnalyzer: 3
+    ClothingEyesHudMedical: 3
     Brutepack: 5
     Ointment: 5
     Bloodpack: 5


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

It seems inconsistent that the Medical HUD is available in Paramedic lockers (see Resources/Prototypes/Catalog/Fills/Lockers/medical.yml), but those Paramedic lockers don't exist on every map. I was under the impression that standard tools like this that may exist on some maps but not others should be added to vending machines. The Medical HUD is an essential tool for some Doctors / Paramedics (despite the bug where it covers progress bars.)

All this PR does is add 3x to the NanoMed vending machine.

I could understand concern that this might be unbalanced, but if it's intended to be a rare, powerful, Head-Only item, I don't think it should _sometimes_ be around for Paramedics (or nosy Doctors) and _sometimes_ not.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

(I think this counts as a minor tweak and doesn't need a pic.)

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: rosieposie
- tweak: Added Medical HUD to NanoMed vending machines.
